### PR TITLE
Types solver improvement

### DIFF
--- a/VSharp.SILI.Core/TypeSolver.fs
+++ b/VSharp.SILI.Core/TypeSolver.fs
@@ -193,8 +193,7 @@ module TypeSolver =
             else
                 let types = t |> Seq.singleton
                 // mock?
-                let mock = getMock None constraints.supertypes
-                candidates(types, Some(mock))
+                candidates(types, None)
         | _ ->
             let validate = satisfiesConstraints constraints subst
             match constraints.subtypes with
@@ -283,14 +282,7 @@ module TypeSolver =
 
     let private solveGenericConstraints getMock indTypesConstraints subst =
         let refineSubst (candidatesList : candidates list) =
-            let pickType (candidates: candidates) =
-                match (Seq.tryHead candidates.OrderedTypes) with
-                | Some t -> ConcreteType t
-                | None ->
-                    match candidates.Mock with
-                    | Some mock -> MockType mock
-                    | None -> __unreachable__()
-            let candidates = candidatesList |> List.map (fun l -> l.AsSymbolicTypes() |> Seq.head)
+            let candidates = candidatesList |> List.map (fun l -> l.Pick())
             let types, _  = List.unzip indTypesConstraints
             List.zip types candidates
             |> PersistentDict.ofSeq

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -509,3 +509,7 @@ module TypeUtils =
         elif isInt x || isUInt x || isLong x || isULong x then x
         elif isIntegral x then typeof<int32>
         else fail()
+        
+    let isMsCoreType (t: Type) =
+        let msCoreNamespacePrefixes = ["Microsoft"; "System"]
+        List.exists (fun ns -> t.Namespace.StartsWith(ns:string)) msCoreNamespacePrefixes


### PR DESCRIPTION
Add `candidates` data structure in order to rank types and not to truncate mock.